### PR TITLE
✨ Add localStorage persistence for scores and progress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,14 +495,19 @@ To update across all projects, run: `~/.claude/scripts/sync-git-workflow.sh`
 
 ## RESUMEN DEL PROYECTO
 
-Plataforma de juegos educativos interactivos con enfoque en aprendizaje geográfico. Cada juego es un módulo independiente con múltiples modos de juego (exploración, aprendizaje, quiz, desafíos).
+Plataforma de juegos educativos interactivos para niños y jóvenes. Cada juego es un módulo independiente con múltiples modos de juego (exploración, aprendizaje, quiz, desafíos). Cubre geografía, ciencias naturales, matemáticas y lenguaje.
 
-**Juegos implementados:**
-- ✅ **Explora Colombia** - Departamentos y capitales de Colombia con mapa interactivo
+**Juegos implementados (7):**
+- ✅ **Explora Colombia** - 32 departamentos y capitales con mapa interactivo
 - ✅ **Capitales de Sudamérica** - 12 países con mapas, datos curiosos y desafíos
+- ✅ **Banderas del Mundo** - 50 países con banderas, capitales, idiomas y monedas
+- ✅ **¿Qué Animal Soy?** - 20 animales con 5 pistas progresivas
+- ✅ **Figuras Geométricas** - 16 figuras 2D/3D con fórmulas y propiedades
+- ✅ **Monumentos Famosos** - 20 monumentos con mapa mundial interactivo
+- ✅ **Palabras Revueltas** - 72 palabras en 6 categorías para ordenar letras
 
 **Objetivos:**
-- Aprendizaje gamificado de geografía
+- Aprendizaje gamificado multi-temático
 - Interfaz atractiva y responsive
 - Múltiples modos de juego para diferentes estilos de aprendizaje
 - Código modular y reutilizable
@@ -519,11 +524,27 @@ interactive-learning-games/
 │   │   │   ├── index.jsx              # Componente principal del juego
 │   │   │   ├── colombia-geo.js        # GeoJSON de Colombia
 │   │   │   └── README.md              # Documentación del juego
-│   │   └── capitales-sudamerica/
-│   │       ├── index.jsx              # Componente principal del juego
-│   │       ├── southamerica-geo.js    # GeoJSON de Sudamérica
-│   │       └── README.md              # Documentación del juego
-│   ├── App.jsx                        # Router principal
+│   │   ├── capitales-sudamerica/
+│   │   │   ├── index.jsx              # Componente principal del juego
+│   │   │   ├── southamerica-geo.js    # GeoJSON de Sudamérica
+│   │   │   └── README.md              # Documentación del juego
+│   │   ├── banderas-mundo/
+│   │   │   ├── index.jsx              # 50 países, banderas y datos
+│   │   │   └── README.md
+│   │   ├── que-animal-soy/
+│   │   │   ├── index.jsx              # 20 animales con pistas progresivas
+│   │   │   └── README.md
+│   │   ├── figuras-geometricas/
+│   │   │   ├── index.jsx              # 16 figuras 2D/3D con SVG
+│   │   │   └── README.md
+│   │   ├── monumentos-famosos/
+│   │   │   ├── index.jsx              # 20 monumentos con mapa
+│   │   │   ├── world-geo.js           # GeoJSON mundial simplificado
+│   │   │   └── README.md
+│   │   └── palabras-revueltas/
+│   │       ├── index.jsx              # 72 palabras en 6 categorías
+│   │       └── README.md
+│   ├── App.jsx                        # Router principal + lazy loading
 │   ├── main.jsx                       # Entry point
 │   └── index.css                      # Estilos globales
 ├── public/
@@ -1180,10 +1201,10 @@ npm run preview
    - Fauna característica
    - Mapa de corrientes
 
-5. **🗺️ Banderas del Mundo**
-   - 195 banderas
-   - Significado de colores
-   - Quiz de reconocimiento
+5. **🧬 Sistema Solar**
+   - Planetas, distancias, composición
+   - Datos de lunas y anillos
+   - Comparaciones de tamaño
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎮 Interactive Learning Games
 
-Plataforma de juegos educativos interactivos enfocados en aprendizaje geográfico. Cada juego ofrece múltiples modos de aprendizaje: exploración con mapas interactivos, flashcards, quizzes y desafíos contra reloj.
+Plataforma de juegos educativos interactivos para niños y jóvenes. Cada juego ofrece múltiples modos de aprendizaje: exploración interactiva, flashcards, quizzes y desafíos contra reloj. Cubre geografía, ciencias naturales, matemáticas y lenguaje.
 
 ![React](https://img.shields.io/badge/React-19.2.0-blue?logo=react)
 ![Vite](https://img.shields.io/badge/Vite-7.3.1-purple?logo=vite)
@@ -29,6 +29,61 @@ Domina las capitales de los 12 países sudamericanos con datos culturales y curi
 - Modo desafío de 60 segundos
 
 [📖 Ver documentación completa](./src/games/capitales-sudamerica/README.md)
+
+### 🌍 Banderas del Mundo
+Aprende las banderas, capitales y datos curiosos de 50 países de todo el mundo.
+
+**Características:**
+- Galería visual con filtro por continente
+- 50 países · Banderas · Capitales · Idiomas · Monedas
+- Datos curiosos por país
+- 4 modos de juego completos
+
+[📖 Ver documentación completa](./src/games/banderas-mundo/README.md)
+
+### 🐾 ¿Qué Animal Soy?
+Adivina el animal con 5 pistas progresivas. ¡Menos pistas usas, más puntos ganas!
+
+**Características:**
+- 20 animales con 5 pistas cada uno
+- Sistema de puntuación progresivo (50→10 puntos)
+- Hábitats, alimentación y curiosidades
+- Modo desafío de 60 segundos
+
+[📖 Ver documentación completa](./src/games/que-animal-soy/README.md)
+
+### 📐 Figuras Geométricas
+Aprende figuras 2D, polígonos y volúmenes 3D con fórmulas, propiedades y quiz interactivos.
+
+**Características:**
+- 16 figuras geométricas (10 2D + 6 3D)
+- Renderizado SVG con perspectiva 3D
+- Fórmulas de área, perímetro y volumen
+- Galería con filtro 2D/3D
+
+[📖 Ver documentación completa](./src/games/figuras-geometricas/README.md)
+
+### 🏛️ Monumentos Famosos
+Ubica los monumentos más icónicos del mundo en un mapa interactivo.
+
+**Características:**
+- 20 monumentos famosos con mapa mundial
+- Modo "Localizar" con puntuación por distancia (Haversine)
+- Año de construcción, país y datos históricos
+- GeoJSON simplificado del mundo
+
+[📖 Ver documentación completa](./src/games/monumentos-famosos/README.md)
+
+### 🔤 Palabras Revueltas
+Ordena las letras desordenadas para formar la palabra correcta.
+
+**Características:**
+- 72 palabras en 6 categorías (animales, frutas, países, profesiones, deportes, colores)
+- Mecánica de arrastrar letras para ordenar
+- Temporizador por palabra (30 segundos)
+- Modo exploración por categoría
+
+[📖 Ver documentación completa](./src/games/palabras-revueltas/README.md)
 
 ## 🚀 Instalación
 
@@ -69,19 +124,18 @@ npm run lint         # Ejecuta ESLint
 
 ## 🎯 Modos de Juego
 
-Todos los juegos incluyen 4 modos complementarios de aprendizaje:
+Cada juego ofrece modos complementarios adaptados a su temática:
 
-### 🗺️ Modo Mapa Interactivo
-- **Exploración libre**: Descubre información tocando el mapa
-- **Encuéntralo**: Desafío de localizar lugares específicos
-- Feedback visual inmediato
-- Contador de progreso
+### 🗺️ Modo Exploración
+- **Mapas interactivos** (juegos geográficos): Exploración libre y modo "Encuéntralo"
+- **Galerías visuales** (banderas, figuras): Navegación con filtros por categoría
+- **Pistas progresivas** (animales): 5 pistas con puntuación decreciente
+- Feedback visual inmediato en todos los modos
 
 ### 📚 Modo Aprender
 - Flashcards con animación flip 3D
-- Navegación secuencial
+- Navegación secuencial con barra de progreso
 - Sistema de marcado "Aprendido"
-- Barra de progreso visual
 - Información completa y datos curiosos
 
 ### 🧠 Modo Quiz
@@ -96,7 +150,6 @@ Todos los juegos incluyen 4 modos complementarios de aprendizaje:
 - Preguntas ilimitadas
 - Timer visual con cambio de color
 - Estadísticas de velocidad
-- Animaciones de urgencia
 
 ## 🛠️ Stack Tecnológico
 
@@ -112,26 +165,41 @@ Todos los juegos incluyen 4 modos complementarios de aprendizaje:
 ```
 interactive-learning-games/
 ├── src/
-│   ├── games/                    # Juegos individuales
-│   │   ├── explora-colombia/
-│   │   │   ├── index.jsx        # Componente principal
-│   │   │   ├── colombia-geo.js  # GeoJSON
-│   │   │   └── README.md        # Documentación
-│   │   └── capitales-sudamerica/
+│   ├── games/                        # Juegos individuales
+│   │   ├── explora-colombia/         # 🇨🇴 Departamentos de Colombia
+│   │   │   ├── index.jsx
+│   │   │   ├── colombia-geo.js       # GeoJSON departamentos
+│   │   │   └── README.md
+│   │   ├── capitales-sudamerica/     # 🌎 Capitales sudamericanas
+│   │   │   ├── index.jsx
+│   │   │   ├── southamerica-geo.js   # GeoJSON países
+│   │   │   └── README.md
+│   │   ├── banderas-mundo/           # 🌍 Banderas de 50 países
+│   │   │   ├── index.jsx
+│   │   │   └── README.md
+│   │   ├── que-animal-soy/           # 🐾 Adivina el animal
+│   │   │   ├── index.jsx
+│   │   │   └── README.md
+│   │   ├── figuras-geometricas/      # 📐 Figuras 2D y 3D
+│   │   │   ├── index.jsx
+│   │   │   └── README.md
+│   │   ├── monumentos-famosos/       # 🏛️ Monumentos del mundo
+│   │   │   ├── index.jsx
+│   │   │   ├── world-geo.js          # GeoJSON mundial
+│   │   │   └── README.md
+│   │   └── palabras-revueltas/       # 🔤 Ordena las letras
 │   │       ├── index.jsx
-│   │       ├── southamerica-geo.js
 │   │       └── README.md
-│   ├── App.jsx                   # Router principal
-│   ├── App.css                   # Estilos de app
-│   ├── main.jsx                  # Entry point
-│   └── index.css                 # Estilos globales
+│   ├── App.jsx                       # Router principal + lazy loading
+│   ├── main.jsx                      # Entry point
+│   └── index.css                     # Estilos globales
 ├── public/
-│   └── _redirects               # Netlify SPA routing
-├── CLAUDE.md                     # Guía para agentes IA
-├── README.md                     # Este archivo
+│   └── _redirects                    # Netlify SPA routing
+├── CLAUDE.md                         # Guía para agentes IA
+├── README.md                         # Este archivo
 ├── package.json
 ├── vite.config.js
-└── netlify.toml                  # Config de deployment
+└── netlify.toml                      # Config de deployment
 ```
 
 ## 🎨 Características de Diseño
@@ -218,10 +286,12 @@ Ver [CLAUDE.md](./CLAUDE.md) para guía completa.
 
 ## 📊 Roadmap
 
-### En Desarrollo
+### Ideas para Nuevos Juegos
 - 🌍 **Capitales de Europa** (50 países)
 - 🏞️ **Ríos del Mundo** (principales ríos)
 - ⛰️ **Montañas Famosas** (picos por continente)
+- 🌊 **Océanos y Mares** (profundidad, fauna)
+- 🧬 **Sistema Solar** (planetas, datos)
 
 ### Futuras Características
 - 🔊 Audio de pronunciación
@@ -230,7 +300,6 @@ Ver [CLAUDE.md](./CLAUDE.md) para guía completa.
 - 📈 Estadísticas detalladas
 - 🌐 Internacionalización (i18n)
 - 🎮 Modo multijugador
-- 🎨 Temas personalizables
 
 ## 🤝 Contribuir
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useState, useEffect } from "react";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import GameErrorBoundary from "./components/GameErrorBoundary";
+import { getAllProgress } from "./hooks/useGameProgress";
 
 const ExploraColombia = lazy(() => import("./games/explora-colombia"));
 const CapitalesSudamerica = lazy(() => import("./games/capitales-sudamerica"));
@@ -95,7 +96,31 @@ function LoadingSpinner() {
   );
 }
 
+function ProgressBadge({ progress }) {
+  if (!progress || !progress.quizTotal) return null;
+  return (
+    <div style={{ display: "flex", gap: 6, marginTop: 6, flexWrap: "wrap" }}>
+      <span style={{ background: "rgba(255,255,255,0.25)", borderRadius: 10, padding: "2px 8px", fontSize: 11, fontWeight: 700 }}>
+        🧠 {progress.quizBest}/{progress.quizTotal}
+      </span>
+      {progress.challengeBest > 0 && (
+        <span style={{ background: "rgba(255,255,255,0.25)", borderRadius: 10, padding: "2px 8px", fontSize: 11, fontWeight: 700 }}>
+          ⚡ {progress.challengeBest}
+        </span>
+      )}
+      {progress.bestStreak > 0 && (
+        <span style={{ background: "rgba(255,255,255,0.25)", borderRadius: 10, padding: "2px 8px", fontSize: 11, fontWeight: 700 }}>
+          🔥 {progress.bestStreak}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function Home() {
+  const [progress, setProgress] = useState({});
+  useEffect(() => { setProgress(getAllProgress()); }, []);
+
   return (
     <div style={homeCtn}>
       <div style={{ textAlign: "center", marginBottom: 8 }}>
@@ -107,32 +132,36 @@ function Home() {
       </div>
 
       <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%", maxWidth: 420 }}>
-        {games.map((g) => (
-          <Link to={g.path} key={g.path} style={{ textDecoration: "none" }}>
-            <div
-              style={{
-                background: g.gradient,
-                borderRadius: 20,
-                padding: "24px 22px",
-                color: "white",
-                cursor: "pointer",
-                transition: "transform 0.2s",
-                boxShadow: "0 6px 25px rgba(0,0,0,0.15)",
-                display: "flex",
-                alignItems: "center",
-                gap: 18,
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.transform = "scale(1.03)")}
-              onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
-            >
-              <span style={{ fontSize: 44 }}>{g.icon}</span>
-              <div>
-                <div style={{ fontSize: 20, fontWeight: 800 }}>{g.title}</div>
-                <div style={{ fontSize: 13, opacity: 0.9, marginTop: 4, lineHeight: 1.4 }}>{g.desc}</div>
+        {games.map((g) => {
+          const p = progress[g.path.slice(1)];
+          return (
+            <Link to={g.path} key={g.path} style={{ textDecoration: "none" }}>
+              <div
+                style={{
+                  background: g.gradient,
+                  borderRadius: 20,
+                  padding: "24px 22px",
+                  color: "white",
+                  cursor: "pointer",
+                  transition: "transform 0.2s",
+                  boxShadow: "0 6px 25px rgba(0,0,0,0.15)",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 18,
+                }}
+                onMouseEnter={(e) => (e.currentTarget.style.transform = "scale(1.03)")}
+                onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
+              >
+                <span style={{ fontSize: 44 }}>{g.icon}</span>
+                <div>
+                  <div style={{ fontSize: 20, fontWeight: 800 }}>{g.title}</div>
+                  <div style={{ fontSize: 13, opacity: 0.9, marginTop: 4, lineHeight: 1.4 }}>{g.desc}</div>
+                  <ProgressBadge progress={p} />
+                </div>
               </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          );
+        })}
       </div>
 
       <div style={{ fontSize: 12, color: "#bbb", textAlign: "center", marginTop: 16 }}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import GameErrorBoundary from "./components/GameErrorBoundary";
 
 const ExploraColombia = lazy(() => import("./games/explora-colombia"));
 const CapitalesSudamerica = lazy(() => import("./games/capitales-sudamerica"));
@@ -148,7 +149,11 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           {games.map((g) => (
-            <Route key={g.path} path={g.path} element={<g.component />} />
+            <Route key={g.path} path={g.path} element={
+              <GameErrorBoundary icon={g.icon}>
+                <g.component />
+              </GameErrorBoundary>
+            } />
           ))}
         </Routes>
       </Suspense>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,13 @@
+import { lazy, Suspense } from "react";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
-import ExploraColombia from "./games/explora-colombia";
-import CapitalesSudamerica from "./games/capitales-sudamerica";
-import BanderasMundo from "./games/banderas-mundo";
-import QueAnimalSoy from "./games/que-animal-soy";
-import FigurasGeometricas from "./games/figuras-geometricas";
-import MonumentosFamosos from "./games/monumentos-famosos";
-import PalabrasRevueltas from "./games/palabras-revueltas";
+
+const ExploraColombia = lazy(() => import("./games/explora-colombia"));
+const CapitalesSudamerica = lazy(() => import("./games/capitales-sudamerica"));
+const BanderasMundo = lazy(() => import("./games/banderas-mundo"));
+const QueAnimalSoy = lazy(() => import("./games/que-animal-soy"));
+const FigurasGeometricas = lazy(() => import("./games/figuras-geometricas"));
+const MonumentosFamosos = lazy(() => import("./games/monumentos-famosos"));
+const PalabrasRevueltas = lazy(() => import("./games/palabras-revueltas"));
 
 const games = [
   {
@@ -66,6 +68,32 @@ const games = [
   },
 ];
 
+function LoadingSpinner() {
+  return (
+    <div style={{
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      minHeight: "100vh",
+      fontFamily: "'Segoe UI', system-ui, -apple-system, sans-serif",
+      background: "linear-gradient(180deg, #fef9f0 0%, #fff5f5 50%, #f0f4ff 100%)",
+      gap: 16,
+    }}>
+      <div style={{
+        width: 48,
+        height: 48,
+        border: "4px solid #e0e0e0",
+        borderTopColor: "#764ba2",
+        borderRadius: "50%",
+        animation: "spin 0.8s linear infinite",
+      }} />
+      <p style={{ color: "#888", fontSize: 15, margin: 0 }}>Cargando juego...</p>
+      <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
+    </div>
+  );
+}
+
 function Home() {
   return (
     <div style={homeCtn}>
@@ -116,12 +144,14 @@ function Home() {
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        {games.map((g) => (
-          <Route key={g.path} path={g.path} element={<g.component />} />
-        ))}
-      </Routes>
+      <Suspense fallback={<LoadingSpinner />}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          {games.map((g) => (
+            <Route key={g.path} path={g.path} element={<g.component />} />
+          ))}
+        </Routes>
+      </Suspense>
     </BrowserRouter>
   );
 }

--- a/src/components/GameErrorBoundary.jsx
+++ b/src/components/GameErrorBoundary.jsx
@@ -1,0 +1,88 @@
+import { Component } from "react";
+import { Link } from "react-router-dom";
+
+export default class GameErrorBoundary extends Component {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <div style={containerStyle}>
+        <div style={cardStyle}>
+          <div style={{ fontSize: 64 }}>{this.props.icon || "🎮"}</div>
+          <h2 style={headingStyle}>Algo salió mal</h2>
+          <p style={messageStyle}>
+            Este juego tuvo un problema inesperado. Puedes volver al inicio e intentarlo de nuevo.
+          </p>
+          <Link to="/" style={{ textDecoration: "none" }}>
+            <button
+              style={buttonStyle}
+              onClick={() => this.setState({ hasError: false })}
+              onMouseEnter={(e) => (e.currentTarget.style.transform = "scale(1.05)")}
+              onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
+            >
+              🏠 Volver al inicio
+            </button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+}
+
+const containerStyle = {
+  fontFamily: "'Segoe UI', system-ui, -apple-system, sans-serif",
+  maxWidth: 480,
+  margin: "0 auto",
+  padding: "40px 16px",
+  minHeight: "100vh",
+  background: "linear-gradient(180deg, #fef9f0 0%, #fff5f5 50%, #f0f4ff 100%)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+const cardStyle = {
+  background: "white",
+  borderRadius: 24,
+  padding: "40px 28px",
+  textAlign: "center",
+  boxShadow: "0 8px 30px rgba(0,0,0,0.1)",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 12,
+};
+
+const headingStyle = {
+  fontSize: 24,
+  fontWeight: 800,
+  margin: 0,
+  color: "#333",
+};
+
+const messageStyle = {
+  fontSize: 15,
+  color: "#777",
+  lineHeight: 1.5,
+  margin: 0,
+};
+
+const buttonStyle = {
+  marginTop: 8,
+  background: "linear-gradient(135deg, #667eea, #764ba2)",
+  color: "white",
+  border: "none",
+  borderRadius: 16,
+  padding: "14px 32px",
+  fontSize: 16,
+  fontWeight: 700,
+  cursor: "pointer",
+  transition: "transform 0.2s",
+  boxShadow: "0 4px 15px rgba(102,126,234,0.4)",
+};

--- a/src/games/banderas-mundo/index.jsx
+++ b/src/games/banderas-mundo/index.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from "react";
+import useGameProgress from "../../hooks/useGameProgress";
 
 /* =================== GAME DATA =================== */
 const COUNTRIES = [
@@ -343,10 +344,11 @@ function GalleryMode({ onBack }) {
 }
 
 /* =================== LEARN MODE =================== */
-function LearnMode({ onBack }) {
+function LearnMode({ onBack, saveLearned }) {
   const [idx, setIdx] = useState(0);
   const [flipped, setFlipped] = useState(false);
   const [learned, setLearned] = useState(new Set());
+  useEffect(() => { if (learned.size > 0) saveLearned?.(learned.size); }, [learned.size]);
   const c = COUNTRIES[idx];
 
   return (
@@ -394,7 +396,7 @@ function LearnMode({ onBack }) {
 }
 
 /* =================== QUIZ MODE =================== */
-function QuizMode({ onBack }) {
+function QuizMode({ onBack, saveQuiz }) {
   const T = 15;
   const [qs, setQs] = useState(() => makeQuestions(T));
   const [qi, setQi] = useState(0);
@@ -404,6 +406,7 @@ function QuizMode({ onBack }) {
   const [bStr, setBStr] = useState(0);
   const [conf, setConf] = useState(0);
   const [done, setDone] = useState(false);
+  useEffect(() => { if (done) saveQuiz?.(sc, T, bStr); }, [done]);
 
   const gen = () => {
     setQs(makeQuestions(T));
@@ -476,7 +479,7 @@ function QuizMode({ onBack }) {
 }
 
 /* =================== CHALLENGE MODE =================== */
-function ChallengeMode({ onBack }) {
+function ChallengeMode({ onBack, saveChallenge }) {
   const [st, setSt] = useState("ready");
   const [qs, setQs] = useState([]);
   const [qi, setQi] = useState(0);
@@ -486,6 +489,7 @@ function ChallengeMode({ onBack }) {
   const [conf, setConf] = useState(0);
   const [str, setStr] = useState(0);
   const ref = useRef(null);
+  useEffect(() => { if (st === "done") saveChallenge?.(sc); }, [st]);
 
   const start = () => {
     setQs(makeQuestions(96));
@@ -591,6 +595,7 @@ function ChallengeMode({ onBack }) {
 export default function BanderasMundo() {
   const [screen, setScreen] = useState("menu");
   const [floats, setFloats] = useState([]);
+  const { saveQuiz, saveChallenge, saveLearned } = useGameProgress("banderas-mundo");
 
   useEffect(() => {
     if (screen !== "menu") return;
@@ -606,7 +611,7 @@ export default function BanderasMundo() {
   if (Screen) {
     return (
       <div style={gameCtn}>
-        <Screen onBack={() => setScreen("menu")} />
+        <Screen onBack={() => setScreen("menu")} saveQuiz={saveQuiz} saveChallenge={saveChallenge} saveLearned={saveLearned} />
       </div>
     );
   }

--- a/src/games/capitales-sudamerica/index.jsx
+++ b/src/games/capitales-sudamerica/index.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { geoMercator, geoPath } from "d3-geo";
+import useGameProgress from "../../hooks/useGameProgress";
 import southAmericaGeo from "./southamerica-geo.js";
 
 const COUNTRIES = [
@@ -304,10 +305,11 @@ function MapMode({ onBack }) {
 }
 
 /* =================== LEARN MODE =================== */
-function LearnMode({ onBack }) {
+function LearnMode({ onBack, saveLearned }) {
   const [idx, setIdx] = useState(0);
   const [flipped, setFlipped] = useState(false);
   const [learned, setLearned] = useState(new Set());
+  useEffect(() => { if (learned.size > 0) saveLearned?.(learned.size); }, [learned.size]);
   const c = COUNTRIES[idx];
 
   return (
@@ -349,7 +351,7 @@ function LearnMode({ onBack }) {
 }
 
 /* =================== QUIZ MODE =================== */
-function QuizMode({ onBack }) {
+function QuizMode({ onBack, saveQuiz }) {
   const [qs, setQs] = useState([]);
   const [qi, setQi] = useState(0);
   const [sel, setSel] = useState(null);
@@ -359,6 +361,7 @@ function QuizMode({ onBack }) {
   const [conf, setConf] = useState(0);
   const [done, setDone] = useState(false);
   const T = 12;
+  useEffect(() => { if (done) saveQuiz?.(sc, T, bStr); }, [done]);
 
   useEffect(() => { gen(); }, []);
 
@@ -423,7 +426,7 @@ function QuizMode({ onBack }) {
 }
 
 /* =================== CHALLENGE MODE =================== */
-function ChallengeMode({ onBack }) {
+function ChallengeMode({ onBack, saveChallenge }) {
   const [st, setSt] = useState("ready");
   const [qs, setQs] = useState([]);
   const [qi, setQi] = useState(0);
@@ -433,6 +436,7 @@ function ChallengeMode({ onBack }) {
   const [conf, setConf] = useState(0);
   const [str, setStr] = useState(0);
   const ref = useRef(null);
+  useEffect(() => { if (st === "done") saveChallenge?.(sc); }, [st]);
 
   const start = () => {
     setQs(makeQuestions(96));
@@ -528,6 +532,7 @@ function ChallengeMode({ onBack }) {
 export default function CapitalesSudamerica() {
   const [screen, setScreen] = useState("menu");
   const [floats, setFloats] = useState([]);
+  const { saveQuiz, saveChallenge, saveLearned } = useGameProgress("capitales-sudamerica");
 
   useEffect(() => {
     if (screen !== "menu") return;
@@ -543,7 +548,7 @@ export default function CapitalesSudamerica() {
   if (Screen) {
     return (
       <div style={gameCtn}>
-        <Screen onBack={() => setScreen("menu")} />
+        <Screen onBack={() => setScreen("menu")} saveQuiz={saveQuiz} saveChallenge={saveChallenge} saveLearned={saveLearned} />
       </div>
     );
   }

--- a/src/games/explora-colombia/index.jsx
+++ b/src/games/explora-colombia/index.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { geoMercator, geoPath, geoCentroid } from "d3-geo";
+import useGameProgress from "../../hooks/useGameProgress";
 import colombiaGeo from "./colombia-geo.js";
 
 const DEPTS = [
@@ -386,10 +387,11 @@ function MapMode({ onBack }) {
 }
 
 /* =================== LEARN MODE =================== */
-function LearnMode({ onBack }) {
+function LearnMode({ onBack, saveLearned }) {
   const [idx, setIdx] = useState(0);
   const [flipped, setFlipped] = useState(false);
   const [learned, setLearned] = useState(new Set());
+  useEffect(() => { if (learned.size > 0) saveLearned?.(learned.size); }, [learned.size]);
   const d = DEPTS[idx];
   const rc = REGIONS[d.r];
 
@@ -429,7 +431,7 @@ function LearnMode({ onBack }) {
 }
 
 /* =================== QUIZ MODE =================== */
-function QuizMode({ onBack }) {
+function QuizMode({ onBack, saveQuiz }) {
   const [qs, setQs] = useState([]);
   const [qi, setQi] = useState(0);
   const [sel, setSel] = useState(null);
@@ -439,6 +441,7 @@ function QuizMode({ onBack }) {
   const [conf, setConf] = useState(0);
   const [done, setDone] = useState(false);
   const T = 15;
+  useEffect(() => { if (done) saveQuiz?.(sc, T, bStr); }, [done]);
 
   useEffect(() => { gen(); }, []);
 
@@ -504,7 +507,7 @@ function QuizMode({ onBack }) {
 }
 
 /* =================== CHALLENGE MODE =================== */
-function ChallengeMode({ onBack }) {
+function ChallengeMode({ onBack, saveChallenge }) {
   const [st, setSt] = useState("ready");
   const [qs, setQs] = useState([]);
   const [qi, setQi] = useState(0);
@@ -514,6 +517,7 @@ function ChallengeMode({ onBack }) {
   const [conf, setConf] = useState(0);
   const [str, setStr] = useState(0);
   const ref = useRef(null);
+  useEffect(() => { if (st === "done") saveChallenge?.(sc); }, [st]);
 
   const start = () => {
     setQs(makeQuestions(96));
@@ -609,6 +613,7 @@ function ChallengeMode({ onBack }) {
 export default function ExploraColombia() {
   const [screen, setScreen] = useState("menu");
   const [floats, setFloats] = useState([]);
+  const { saveQuiz, saveChallenge, saveLearned } = useGameProgress("explora-colombia");
 
   useEffect(() => {
     if (screen !== "menu") return;
@@ -624,7 +629,7 @@ export default function ExploraColombia() {
   if (Screen) {
     return (
       <div style={gameCtn}>
-        <Screen onBack={() => setScreen("menu")} />
+        <Screen onBack={() => setScreen("menu")} saveQuiz={saveQuiz} saveChallenge={saveChallenge} saveLearned={saveLearned} />
       </div>
     );
   }

--- a/src/games/figuras-geometricas/index.jsx
+++ b/src/games/figuras-geometricas/index.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from "react";
+import useGameProgress from "../../hooks/useGameProgress";
 
 /* ───────── DATOS DEL JUEGO ───────── */
 
@@ -737,10 +738,11 @@ function ExploreMode({ onBack }) {
 
 /* ───────── MODO APRENDER (FLASHCARDS) ───────── */
 
-function LearnMode({ onBack }) {
+function LearnMode({ onBack, saveLearned }) {
   const [idx, setIdx] = useState(0);
   const [flipped, setFlipped] = useState(false);
   const [learned, setLearned] = useState(new Set());
+  useEffect(() => { if (learned.size > 0) saveLearned?.(learned.size); }, [learned.size]);
 
   const shape = SHAPES[idx];
 
@@ -978,7 +980,7 @@ function makeQuestions(count) {
 
 const TOTAL_Q = 15;
 
-function QuizMode({ onBack }) {
+function QuizMode({ onBack, saveQuiz }) {
   const [qs] = useState(() => makeQuestions(TOTAL_Q));
   const [qi, setQi] = useState(0);
   const [sel, setSel] = useState(null);
@@ -987,6 +989,7 @@ function QuizMode({ onBack }) {
   const [bStr, setBStr] = useState(0);
   const [conf, setConf] = useState(0);
   const [done, setDone] = useState(false);
+  useEffect(() => { if (done) saveQuiz?.(sc, TOTAL_Q, bStr); }, [done]);
 
   const pick = (o) => {
     if (sel !== null) return;
@@ -1073,7 +1076,7 @@ function QuizMode({ onBack }) {
 
 /* ───────── MODO DESAFÍO ───────── */
 
-function ChallengeMode({ onBack }) {
+function ChallengeMode({ onBack, saveChallenge }) {
   const [qs] = useState(() => makeQuestions(96));
   const [qi, setQi] = useState(0);
   const [sel, setSel] = useState(null);
@@ -1083,6 +1086,7 @@ function ChallengeMode({ onBack }) {
   const [st, setSt] = useState("ready");
   const [conf, setConf] = useState(0);
   const ref = useRef(null);
+  useEffect(() => { if (st === "done") saveChallenge?.(sc); }, [st]);
 
   useEffect(() => {
     if (st !== "playing") return;
@@ -1234,6 +1238,7 @@ function ChallengeMode({ onBack }) {
 export default function FigurasGeometricas() {
   const [screen, setScreen] = useState("menu");
   const [floats, setFloats] = useState([]);
+  const { saveQuiz, saveChallenge, saveLearned } = useGameProgress("figuras-geometricas");
 
   useEffect(() => {
     if (screen !== "menu") return;
@@ -1264,7 +1269,7 @@ export default function FigurasGeometricas() {
   if (Screen) {
     return (
       <div style={gameCtn}>
-        <Screen onBack={() => setScreen("menu")} />
+        <Screen onBack={() => setScreen("menu")} saveQuiz={saveQuiz} saveChallenge={saveChallenge} saveLearned={saveLearned} />
       </div>
     );
   }

--- a/src/games/monumentos-famosos/index.jsx
+++ b/src/games/monumentos-famosos/index.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { geoNaturalEarth1, geoPath, geoGraticule } from "d3-geo";
+import useGameProgress from "../../hooks/useGameProgress";
 import worldGeo from "./world-geo.js";
 
 // =================== MONUMENTS DATA ===================
@@ -438,10 +439,11 @@ function LocateMode({ onBack }) {
 }
 
 /* =================== LEARN MODE =================== */
-function LearnMode({ onBack }) {
+function LearnMode({ onBack, saveLearned }) {
   const [idx, setIdx] = useState(0);
   const [flipped, setFlipped] = useState(false);
   const [learned, setLearned] = useState(new Set());
+  useEffect(() => { if (learned.size > 0) saveLearned?.(learned.size); }, [learned.size]);
   const m = MONUMENTS[idx];
 
   return (
@@ -498,7 +500,7 @@ function LearnMode({ onBack }) {
 }
 
 /* =================== QUIZ MODE =================== */
-function QuizMode({ onBack }) {
+function QuizMode({ onBack, saveQuiz }) {
   const [qs, setQs] = useState([]);
   const [qi, setQi] = useState(0);
   const [sel, setSel] = useState(null);
@@ -508,6 +510,7 @@ function QuizMode({ onBack }) {
   const [conf, setConf] = useState(0);
   const [done, setDone] = useState(false);
   const T = 15;
+  useEffect(() => { if (done) saveQuiz?.(sc, T, bStr); }, [done]);
 
   useEffect(() => { gen(); }, []);
 
@@ -572,7 +575,7 @@ function QuizMode({ onBack }) {
 }
 
 /* =================== CHALLENGE MODE =================== */
-function ChallengeMode({ onBack }) {
+function ChallengeMode({ onBack, saveChallenge }) {
   const [st, setSt] = useState("ready");
   const [qs, setQs] = useState([]);
   const [qi, setQi] = useState(0);
@@ -582,6 +585,7 @@ function ChallengeMode({ onBack }) {
   const [conf, setConf] = useState(0);
   const [str, setStr] = useState(0);
   const ref = useRef(null);
+  useEffect(() => { if (st === "done") saveChallenge?.(sc); }, [st]);
 
   const start = () => {
     setQs(makeQuestions(96));
@@ -677,6 +681,7 @@ function ChallengeMode({ onBack }) {
 export default function MonumentosFamosos() {
   const [screen, setScreen] = useState("menu");
   const [floats, setFloats] = useState([]);
+  const { saveQuiz, saveChallenge, saveLearned } = useGameProgress("monumentos-famosos");
 
   useEffect(() => {
     if (screen !== "menu") return;
@@ -692,7 +697,7 @@ export default function MonumentosFamosos() {
   if (Screen) {
     return (
       <div style={gameCtn}>
-        <Screen onBack={() => setScreen("menu")} />
+        <Screen onBack={() => setScreen("menu")} saveQuiz={saveQuiz} saveChallenge={saveChallenge} saveLearned={saveLearned} />
       </div>
     );
   }

--- a/src/games/palabras-revueltas/index.jsx
+++ b/src/games/palabras-revueltas/index.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import useGameProgress from "../../hooks/useGameProgress";
 
 /* ───────────────── DATOS DEL JUEGO ───────────────── */
 
@@ -535,11 +536,12 @@ function WordPuzzle({ wordData, onSolved, onFailed, timeLimit, showHint, showCat
 
 /* ───────────────── MODO EXPLORAR (Categorías) ───────────────── */
 
-function ExploreMode({ onBack }) {
+function ExploreMode({ onBack, saveLearned }) {
   const [selectedCat, setSelectedCat] = useState(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [flipped, setFlipped] = useState(false);
   const [learned, setLearned] = useState(new Set());
+  useEffect(() => { if (learned.size > 0) saveLearned?.(learned.size); }, [learned.size]);
 
   if (!selectedCat) {
     return (
@@ -908,13 +910,14 @@ function LearnMode({ onBack }) {
 
 const QUIZ_TOTAL = 12;
 
-function QuizMode({ onBack }) {
+function QuizMode({ onBack, saveQuiz }) {
   const [words, setWords] = useState(() => shuffle(ALL_WORDS).slice(0, QUIZ_TOTAL));
   const [currentIndex, setCurrentIndex] = useState(0);
   const [score, setScore] = useState(0);
   const [streak, setStreak] = useState(0);
   const [done, setDone] = useState(false);
   const [confetti, setConfetti] = useState(0);
+  useEffect(() => { if (done) saveQuiz?.(score, QUIZ_TOTAL, streak); }, [done]);
 
   const reset = () => {
     setWords(shuffle(ALL_WORDS).slice(0, QUIZ_TOTAL));
@@ -1002,7 +1005,7 @@ function QuizMode({ onBack }) {
 
 /* ───────────────── MODO DESAFÍO (Contrarreloj) ───────────────── */
 
-function ChallengeMode({ onBack }) {
+function ChallengeMode({ onBack, saveChallenge }) {
   const [status, setStatus] = useState("ready"); // ready | playing | done
   const [words, setWords] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -1011,6 +1014,7 @@ function ChallengeMode({ onBack }) {
   const [confetti, setConfetti] = useState(0);
   const [wordKey, setWordKey] = useState(0);
   const globalTimerRef = useRef(null);
+  useEffect(() => { if (status === "done") saveChallenge?.(score); }, [status]);
 
   const start = () => {
     setWords(shuffle(ALL_WORDS));
@@ -1150,6 +1154,7 @@ function ChallengeMode({ onBack }) {
 export default function PalabrasRevueltas() {
   const [screen, setScreen] = useState("menu");
   const [floats, setFloats] = useState([]);
+  const { saveQuiz, saveChallenge, saveLearned } = useGameProgress("palabras-revueltas");
 
   useEffect(() => {
     if (screen !== "menu") return;
@@ -1180,7 +1185,7 @@ export default function PalabrasRevueltas() {
   if (Screen) {
     return (
       <div style={gameCtn}>
-        <Screen onBack={() => setScreen("menu")} />
+        <Screen onBack={() => setScreen("menu")} saveQuiz={saveQuiz} saveChallenge={saveChallenge} saveLearned={saveLearned} />
       </div>
     );
   }

--- a/src/games/que-animal-soy/index.jsx
+++ b/src/games/que-animal-soy/index.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import useGameProgress from "../../hooks/useGameProgress";
 
 /* =================== DATOS DEL JUEGO =================== */
 const ANIMALS = [
@@ -472,10 +473,11 @@ function ClueMode({ onBack }) {
 }
 
 /* =================== MODO APRENDER =================== */
-function LearnMode({ onBack }) {
+function LearnMode({ onBack, saveLearned }) {
   const [idx, setIdx] = useState(0);
   const [flipped, setFlipped] = useState(false);
   const [learned, setLearned] = useState(new Set());
+  useEffect(() => { if (learned.size > 0) saveLearned?.(learned.size); }, [learned.size]);
   const a = ANIMALS[idx];
 
   return (
@@ -544,7 +546,7 @@ function LearnMode({ onBack }) {
 }
 
 /* =================== MODO QUIZ =================== */
-function QuizMode({ onBack }) {
+function QuizMode({ onBack, saveQuiz }) {
   const T = 15;
   const [qs, setQs] = useState([]);
   const [qi, setQi] = useState(0);
@@ -554,6 +556,7 @@ function QuizMode({ onBack }) {
   const [bStr, setBStr] = useState(0);
   const [conf, setConf] = useState(0);
   const [done, setDone] = useState(false);
+  useEffect(() => { if (done) saveQuiz?.(sc, T, bStr); }, [done]);
 
   useEffect(() => { gen(); }, []);
 
@@ -650,7 +653,7 @@ function QuizMode({ onBack }) {
 }
 
 /* =================== MODO DESAFÍO =================== */
-function ChallengeMode({ onBack }) {
+function ChallengeMode({ onBack, saveChallenge }) {
   const [st, setSt] = useState("ready");
   const [rounds, setRounds] = useState([]);
   const [ri, setRi] = useState(0);
@@ -661,6 +664,7 @@ function ChallengeMode({ onBack }) {
   const [conf, setConf] = useState(0);
   const [str, setStr] = useState(0);
   const ref = useRef(null);
+  useEffect(() => { if (st === "done") saveChallenge?.(sc); }, [st]);
 
   const start = () => {
     const picked = [];
@@ -827,6 +831,7 @@ function ChallengeMode({ onBack }) {
 export default function QueAnimalSoy() {
   const [screen, setScreen] = useState("menu");
   const [floats, setFloats] = useState([]);
+  const { saveQuiz, saveChallenge, saveLearned } = useGameProgress("que-animal-soy");
 
   useEffect(() => {
     if (screen !== "menu") return;
@@ -842,7 +847,7 @@ export default function QueAnimalSoy() {
   if (Screen) {
     return (
       <div style={gameCtn}>
-        <Screen onBack={() => setScreen("menu")} />
+        <Screen onBack={() => setScreen("menu")} saveQuiz={saveQuiz} saveChallenge={saveChallenge} saveLearned={saveLearned} />
       </div>
     );
   }

--- a/src/hooks/useGameProgress.js
+++ b/src/hooks/useGameProgress.js
@@ -1,0 +1,69 @@
+import useLocalStorage from "./useLocalStorage";
+
+const STORAGE_KEY = "ilg_progress";
+
+const empty = {
+  quizBest: 0,
+  quizTotal: 0,
+  challengeBest: 0,
+  bestStreak: 0,
+  learnedCount: 0,
+  gamesPlayed: 0,
+};
+
+export default function useGameProgress(gameId) {
+  const [all, setAll] = useLocalStorage(STORAGE_KEY, {});
+
+  const progress = all[gameId] || { ...empty };
+
+  const save = (patch) =>
+    setAll((prev) => ({
+      ...prev,
+      [gameId]: { ...(prev[gameId] || { ...empty }), ...patch },
+    }));
+
+  const saveQuiz = (score, total, streak) => {
+    const cur = all[gameId] || { ...empty };
+    const pct = total > 0 ? score / total : 0;
+    const curPct = cur.quizTotal > 0 ? cur.quizBest / cur.quizTotal : 0;
+
+    const patch = { gamesPlayed: cur.gamesPlayed + 1 };
+
+    if (pct > curPct) {
+      patch.quizBest = score;
+      patch.quizTotal = total;
+    }
+    if (streak > cur.bestStreak) {
+      patch.bestStreak = streak;
+    }
+    save(patch);
+  };
+
+  const saveChallenge = (score) => {
+    const cur = all[gameId] || { ...empty };
+    const patch = { gamesPlayed: cur.gamesPlayed + 1 };
+    if (score > cur.challengeBest) {
+      patch.challengeBest = score;
+    }
+    save(patch);
+  };
+
+  const saveLearned = (count) => {
+    const cur = all[gameId] || { ...empty };
+    if (count > cur.learnedCount) {
+      save({ learnedCount: count });
+    }
+  };
+
+  return { progress, saveQuiz, saveChallenge, saveLearned };
+}
+
+/** Read all progress (no hook, for use outside React components) */
+export function getAllProgress() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}

--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,0 +1,27 @@
+import { useState, useCallback } from "react";
+
+export default function useLocalStorage(key, initialValue) {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = localStorage.getItem(key);
+      return item !== null ? JSON.parse(item) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  const setValue = useCallback(
+    (value) => {
+      try {
+        const next = typeof value === "function" ? value(storedValue) : value;
+        setStoredValue(next);
+        localStorage.setItem(key, JSON.stringify(next));
+      } catch {
+        /* quota exceeded — silently ignore */
+      }
+    },
+    [key, storedValue],
+  );
+
+  return [storedValue, setValue];
+}


### PR DESCRIPTION
## Summary
- Created `useLocalStorage` and `useGameProgress` shared hooks for persisting game progress
- Integrated localStorage persistence into all 7 games (quiz best score, challenge best score, best streak, learned count)
- Home screen game cards now display progress badges (🧠 quiz best, ⚡ challenge best, 🔥 best streak)

## Changes
- **New**: `src/hooks/useLocalStorage.js` — generic localStorage hook with JSON serialization
- **New**: `src/hooks/useGameProgress.js` — game-specific progress tracking (saveQuiz, saveChallenge, saveLearned)
- **Modified**: All 7 game `index.jsx` files — integrated progress hooks via prop threading
- **Modified**: `src/App.jsx` — added `ProgressBadge` component and progress loading on home screen

## Test plan
- [ ] Play each game mode (quiz, challenge, learn) and verify scores persist across page reloads
- [ ] Confirm home screen shows progress badges after completing a quiz
- [ ] Verify best scores only update when new score exceeds previous best
- [ ] Test with cleared localStorage (fresh start shows no badges)
- [ ] Mobile responsive check on progress badges

Closes #11